### PR TITLE
Included copy-to-clipboard functionality at Inference page

### DIFF
--- a/web/src/containers/InferenceJobs/InferenceJobDetails.js
+++ b/web/src/containers/InferenceJobs/InferenceJobDetails.js
@@ -99,6 +99,10 @@ class InferenceJobDetails extends React.Component {
     this.props.push(url)
   }
 
+  handleCopy = () => {
+    navigator.clipboard.writeText(this.state.selectedInferenceJob.predictor_host)
+  }
+
   render() {
     const { classes } = this.props
 
@@ -162,6 +166,15 @@ class InferenceJobDetails extends React.Component {
             {this.state.selectedInferenceJob.datetime_started &&
               (
                 <>
+                <Grid item >
+                    <Button
+                      onClick={this.handleCopy}
+                      color="secondary"
+                      variant="contained"
+                    >
+                      Copy Link
+                    </Button>
+                  </Grid>
                   <Grid item >
                     <Button
                       onClick={this.handleClickRunPrediction}


### PR DESCRIPTION
To address issue raised in Singa-Easy repo: [Provide a button to copy the inference host url into clipboard #25](https://github.com/nusdbsystem/singa-easy/issues/25)