### PR TITLE
Fix dockerfile node version problem

### DIFF
--- a/dockerfiles/web_admin.Dockerfile
+++ b/dockerfiles/web_admin.Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM node:13.5.0-alpine3.11
+FROM node:14.4.0-alpine3.11
 
 ARG DOCKER_WORKDIR_PATH
 RUN mkdir -p $DOCKER_WORKDIR_PATH

--- a/dockerfiles/web_admin.Dockerfile
+++ b/dockerfiles/web_admin.Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM node:14.4.0-alpine3.11
+FROM node:13.7.0-alpine3.11
 
 ARG DOCKER_WORKDIR_PATH
 RUN mkdir -p $DOCKER_WORKDIR_PATH


### PR DESCRIPTION
From this issue: https://github.com/nusdbsystem/singa-auto/issues/85
It displays the error
`error browserslist@4.12.1: The engine "node" is incompatible with this module. Expected version "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7". Got "13.5.0"`
So a solution is to update the node from 13.5 to somewhere more than 13.7  

From https://hub.docker.com/r/i386/node/ , this PR select node 14.4.0

If 14.4.0 is too new, can try exactly 13.7