### PR TITLE
Fixing Kafka issues 

### DIFF
--- a/examples/models/pos_tagging/BigramHmm.py
+++ b/examples/models/pos_tagging/BigramHmm.py
@@ -49,7 +49,7 @@ class BigramHmm(BaseModel):
                                                   sents_tags)
         utils.logger.log('No. of tags: {}'.format(self._num_tags))
 
-    def evaluate(self, dataset_path):
+    def evaluate(self, dataset_path, **kwargs):
         dataset = utils.dataset.load_dataset_of_corpus(dataset_path)
         (sents_tokens, sents_tags) = zip(*[zip(*sent) for sent in dataset])
         (sents_pred_tags) = self._tag_sents(self._num_tags, sents_tokens,

--- a/examples/models/pos_tagging/CRFClf.py
+++ b/examples/models/pos_tagging/CRFClf.py
@@ -73,7 +73,7 @@ class CRFClf(BaseModel):
                                          labels=self._clf.classes_)
         utils.logger.log('Train accuracy: {}'.format(accuracy))
 
-    def evaluate(self, dataset_path):
+    def evaluate(self, dataset_path, **kwargs):
         with open(dataset_path, "rb") as fp:
             data = pickle.load(fp)
 

--- a/singa_auto/datasets/dataset.py
+++ b/singa_auto/datasets/dataset.py
@@ -221,7 +221,6 @@ class CorpusDataset(ModelDataset):
     '''
 
     def __init__(self, dataset_path, tags, split_by):
-        super().__init__(dataset_path)
         self.tags = tags
         (self.size, self.tag_num_classes, self.max_token_len, self.max_sent_len, self._sents) = \
             self._load(dataset_path, self.tags, split_by)
@@ -291,7 +290,6 @@ class AudioFilesDataset(ModelDataset):
     '''
 
     def __init__(self, dataset_path, dataset_dir):
-        super().__init__(dataset_path)
         self._dataset_dir = dataset_dir
         self.df = self._load(dataset_path)
 

--- a/singa_auto/kafka/inference_cache.py
+++ b/singa_auto/kafka/inference_cache.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 RUNNING_INFERENCE_WORKERS = 'INFERENCE_WORKERS'
 QUERIES_QUEUE = 'QUERIES'
 PREDICTIONS_QUEUE = 'PREDICTIONS'
+API_VERSION = (0, 10, 1)
 
 
 class InferenceCache(object):
@@ -51,7 +52,8 @@ class InferenceCache(object):
         self.connection_url = [
             f'{host}:{port}' for host, port in zip(hostlist, portlist)
         ]
-        self.producer = KafkaProducer(bootstrap_servers=self.connection_url,
+        self.producer = KafkaProducer(api_version=API_VERSION,
+                                      bootstrap_servers=self.connection_url,
                                       max_request_size=134217728,
                                       buffer_memory=134217728)
 
@@ -72,6 +74,7 @@ class InferenceCache(object):
 
         prediction_consumer = KafkaConsumer(
             name,
+            api_version=API_VERSION,
             bootstrap_servers=self.connection_url,
             auto_offset_reset='earliest',
             group_id=PREDICTIONS_QUEUE)
@@ -104,6 +107,7 @@ class InferenceCache(object):
         while True:
             try:
                 query_consumer = KafkaConsumer(name,
+                                               api_version=API_VERSION,
                                                bootstrap_servers=self.connection_url,
                                                auto_offset_reset='earliest',
                                                group_id=QUERIES_QUEUE)


### PR DESCRIPTION
Previously, this error happens occasionally,

  File "/root/singa_auto/kafka/inference_cache.py", line 109, in pop_queries_for_worker
    group_id=QUERIES_QUEUE)
  File "/usr/local/envs/singa_auto/lib/python3.6/site-packages/kafka/consumer/group.py", line 353, in __init__
    self._client = KafkaClient(metrics=self._metrics, **self.config)
  File "/usr/local/envs/singa_auto/lib/python3.6/site-packages/kafka/client_async.py", line 239, in __init__
    self.config['api_version'] = self.check_version(timeout=check_timeout)
  File "/usr/local/envs/singa_auto/lib/python3.6/site-packages/kafka/client_async.py", line 892, in check_version
    raise Errors.NoBrokersAvailable()
kafka.errors.NoBrokersAvailable: NoBrokersAvailable

I think it is caused by self.check_version, 
One possible approach is fix the api_version in kafka producer/consumer, and skip the version check

