### PR TITLE
Fix security alerts "Out-of-bounds read in Pillow"

### DIFF
--- a/docs/src/user/model-development.rst
+++ b/docs/src/user/model-development.rst
@@ -120,7 +120,7 @@ Your model will be run in Python 3.6 with the following Python libraries pre-ins
 
         requests==2.20.0
         numpy==1.14.5
-        Pillow==5.3.0
+        Pillow==7.1.0
 
 Additionally, you'll specify a list of Python dependencies to be installed for your model, 
 prior to model training and inference. This is configurable with the ``dependencies`` option 

--- a/singa_auto/requirements.txt
+++ b/singa_auto/requirements.txt
@@ -5,7 +5,7 @@ Flask-Cors==3.0.6
 opencv-python
 requests==2.20.0
 numpy==1.14.5
-Pillow==5.3.0
+Pillow==7.1.0
 tqdm==4.28.1
 msgpack==0.6.1
 pandas==0.24.2


### PR DESCRIPTION
In libImaging/SgiRleDecode.c in Pillow through 7.0.0, a number of out-of-bounds reads exist in the parsing of SGI image files, a different issue than CVE-2020-5311.

Affected versions (<7.1.0)       Patched versions (7.1.0)

So the solution is to use 7.1.0 or higher