### PR TITLE
Add gpu scheduler

### DIFF
--- a/singa_auto_scheduler/MakeFile
+++ b/singa_auto_scheduler/MakeFile
@@ -1,0 +1,19 @@
+
+
+
+# if run on ubuntu, must build at ubuntu
+
+# build sanodemonitor
+go build -o=sanodemonitor ./cmd/nodemonitor
+
+docker build --no-cache -t singaauto/singa_auto_nodegpumonitor:dev -f dockerfiles/sagpumonitor.Dockerfile .
+
+docker push singaauto/singa_auto_nodegpumonitor:dev
+
+# build sascheduler
+
+go build -o=sascheduler ./cmd/scheduler
+
+docker build --no-cache -t singaauto/singa_auto_scheduler:dev -f dockerfiles/sascheduler.Dockerfile .
+
+docker push singaauto/singa_auto_scheduler:dev

--- a/singa_auto_scheduler/cmd/nodemonitor/main.go
+++ b/singa_auto_scheduler/cmd/nodemonitor/main.go
@@ -1,0 +1,61 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package main
+
+import (
+	"fmt"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/collection"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/controller"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/crontabjob"
+	"github.com/robfig/cron"
+	"os"
+	"sync"
+)
+
+func main() {
+	// wg has Add(), Done(), Wait()
+	var wg sync.WaitGroup
+	fmt.Println("Init Mode, Node from env")
+	// Get info from envs
+	collection.Node = os.Getenv("NODE_NAME")
+	collection.Mode = os.Getenv("MODE")
+
+	// Init the node status
+	fmt.Println("Init Node status")
+	controller.InitNodeInfo(collection.Mode)
+	controller.PrintNodeInfo()
+	controller.InitInClusterConfig()
+
+	// Update node gpu info every 1 min
+	c := cron.New()
+	fmt.Println("Init Crontabjob")
+	crontabjob.Update(c, collection.Node)
+
+	// must provide the address of wg, otherwise deadlock
+	// // Start the cron scheduler in its own go-routine,
+	// or no-op if already started.
+	crontabjob.Start(c, &wg)
+
+	//stop the daemonset
+	defer controller.CleanNodeLabel(collection.Node)
+	defer c.Stop()
+
+	// main process keep waiting, until counter inside wg is 0
+	// dont call
+	wg.Wait()
+}

--- a/singa_auto_scheduler/cmd/scheduler/main.go
+++ b/singa_auto_scheduler/cmd/scheduler/main.go
@@ -1,0 +1,38 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package main
+
+import (
+	"fmt"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler"
+	"k8s.io/component-base/logs"
+	"math/rand"
+	"os"
+	"time"
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+	command := sascheduler.Register()
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	if err := command.Execute(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/singa_auto_scheduler/deploy/singa-auto-monitor.yaml
+++ b/singa_auto_scheduler/deploy/singa-auto-monitor.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sasche
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sasche-cr
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+      - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sasche-sa
+  namespace: sasche
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sasche-crb
+  namespace: sasche
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sasche-cr
+subjects:
+  - kind: ServiceAccount
+    name: sasche-sa
+    namespace: sasche
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sasche
+  namespace: sasche
+  labels:
+    app: sasche
+spec:
+  selector:
+    matchLabels:
+      app: sasche
+  template:
+    metadata:
+      labels:
+        app: sasche
+    spec:
+      serviceAccountName: sasche-sa
+      containers:
+        - name: sasche
+          image: singaauto/singa_auto_nodegpumonitor:dev
+          imagePullPolicy: Always
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+            - name: MODE
+              value: "MaxFreeMemory"
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+      terminationGracePeriodSeconds: 30

--- a/singa_auto_scheduler/deploy/singa-auto-scheduler.yaml
+++ b/singa_auto_scheduler/deploy/singa-auto-scheduler.yaml
@@ -1,0 +1,223 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: kube-system
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1alpha1
+    kind: KubeSchedulerConfiguration
+    schedulerName: sascheduler
+    leaderElection:
+      leaderElect: true
+      lockObjectName: sascheduler
+      lockObjectNamespace: kube-system
+    plugins:
+      queueSort:
+        enabled:
+          - name: "sascheduler"
+      filter:
+        enabled:
+        - name: "sascheduler"
+      score:
+        enabled:
+        - name: "sascheduler"
+      postFilter:
+        enabled:
+        - name: "sascheduler"
+    pluginConfig:
+    - name: "sascheduler"
+      args: {"master": "master", "kubeconfig": "kubeconfig"}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sascheduler
+  namespace: kube-system
+  labels:
+    component: sascheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: sascheduler
+  template:
+    metadata:
+      labels:
+        component: sascheduler
+    spec:
+      serviceAccount: sascheduler-sa
+      priorityClassName: system-cluster-critical
+      volumes:
+        - name: scheduler-config
+          configMap:
+            name: scheduler-config
+      containers:
+        - name: sascheduler
+          image: singaauto/singa_auto_scheduler:dev
+          imagePullPolicy: Always
+          args:
+            - sascheduler
+            - --config=/config/scheduler-config.yaml
+            - --v=1
+          resources:
+            requests:
+              cpu: "50m"
+          volumeMounts:
+            - name: scheduler-config
+              mountPath: /config
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sascheduler-cr
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resourceNames:
+      - sascheduler
+    resources:
+      - endpoints
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - pods/binding
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
+      - csinodes
+    verbs:
+      - watch
+      - list
+      - get
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sascheduler-sa
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sascheduler-crb
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sascheduler-cr
+subjects:
+  - kind: ServiceAccount
+    name: sascheduler-sa
+    namespace: kube-system

--- a/singa_auto_scheduler/dockerfiles/sagpumonitor.Dockerfile
+++ b/singa_auto_scheduler/dockerfiles/sagpumonitor.Dockerfile
@@ -1,0 +1,7 @@
+FROM nvidia/cuda:9.0-base-ubuntu16.04
+
+WORKDIR /
+
+COPY sanodemonitor /usr/local/bin
+
+CMD ["sanodemonitor"]

--- a/singa_auto_scheduler/dockerfiles/sascheduler.Dockerfile
+++ b/singa_auto_scheduler/dockerfiles/sascheduler.Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:stretch-slim
+
+WORKDIR /
+
+COPY sascheduler /usr/local/bin
+
+CMD ["sascheduler"]

--- a/singa_auto_scheduler/go.mod
+++ b/singa_auto_scheduler/go.mod
@@ -1,0 +1,42 @@
+module github.com/naili-xing/singa_auto_scheduler
+
+go 1.14
+
+require (
+	github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20200116003318-021662a21098
+	github.com/robfig/cron v1.2.0
+	github.com/spf13/cobra v0.0.5
+	k8s.io/api v0.17.1
+	k8s.io/apimachinery v1.16.2
+	k8s.io/client-go v0.0.0
+	k8s.io/component-base v0.0.0
+	k8s.io/klog v1.0.0
+	k8s.io/kubernetes v1.17.1
+)
+
+replace (
+	k8s.io/api => k8s.io/api v0.0.0-20191122220107-b5267f2975e0
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191122222427-64482ea217ff
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191121175448-79c2a76c473a
+	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20191121180716-5a28f8b2ad8e
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20191122222818-9150eb3ded31
+	k8s.io/client-go => k8s.io/client-go v0.0.0-20191121175918-3a262fe58afa
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.0.0-20191121022508-6371aabbd7a7
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.0.0-20191122223827-289de4a64c1c
+	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20191121015212-c4c8f8345c7e
+	k8s.io/component-base => k8s.io/component-base v0.0.0-20191122163614-46ba8a4433be
+	k8s.io/cri-api => k8s.io/cri-api v0.0.0-20191121183020-775aa3c1cf73
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.0.0-20191121022617-4b18d293964d
+	k8s.io/gengo => k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.0.0-20191122221605-1e8d331e4dcc
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.0.0-20191122223648-5cfd5067047c
+	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.0.0-20191122223145-16f2c0c680a0
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.0.0-20191121022142-fe73241eced9
+	k8s.io/kubectl => k8s.io/kubectl v0.0.0-20191122225023-1e3c8b70f494
+	k8s.io/kubelet => k8s.io/kubelet v0.0.0-20191122223325-9316382755ad
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.0.0-20191122224431-860df69ff5cc
+	k8s.io/metrics => k8s.io/metrics v0.0.0-20191122222628-19ed227de2b6
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.0.0-20191122221846-294c70c3d5d4
+	k8s.io/utils => k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6
+)

--- a/singa_auto_scheduler/pkg/sanodemonitor/collection/computation.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/collection/computation.go
@@ -1,0 +1,86 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package collection
+
+import (
+	"errors"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+	"strconv"
+	"strings"
+)
+
+func (g *GPU) CalculateScoreWithMaxFreeMemoryMode() uint64 {
+	// with the simplest method, score is the value of FreeMemory
+	return g.FreeMemory
+}
+
+// get the summary of GPU, with format of GPU_0.GPU_1.GPU_2 for example
+func CalculateGpuSummary() string {
+	var GpuFreeMemorys []string
+	for _, g := range GPUs {
+		element := strings.Join(
+			[]string{
+				strconv.FormatInt(int64(g.ID), 10),
+				strconv.FormatInt(int64(g.FreeMemory), 10)},
+			"_")
+		GpuFreeMemorys = append(GpuFreeMemorys, element)
+	}
+	return strings.Join(GpuFreeMemorys, ".")
+}
+
+// calculate the total GPU free memory inside a node
+func CalculateGPUFreeMemorySum() uint64 {
+	var Sum uint64 = 0
+	for _, g := range GPUs {
+		Sum += g.FreeMemory
+	}
+	if Sum == 0 {
+		log.ErrPrint("CalculateGPUFreeMemorySum", errors.New("The Sum of the GPU memory is 0. "))
+		return 0
+	}
+	return Sum
+}
+
+func CalculateBestGPUWithMaxFreeMemoryMode() GPU {
+	var (
+		GpuScores []GpuScore
+		Max       uint64 = 0
+		Device    GPU
+	)
+	for _, g := range GPUs {
+		if g.Health == "Unhealthy" {
+			GpuScores = append(GpuScores, GpuScore{
+				Device: g,
+				Score:  0,
+			})
+			continue
+		} else {
+			GpuScores = append(GpuScores, GpuScore{
+				Device: g,
+				Score:  g.CalculateScoreWithMaxFreeMemoryMode(),
+			})
+		}
+	}
+	for _, s := range GpuScores {
+		if s.Score > Max {
+			Max = s.Score
+			Device = s.Device
+		}
+	}
+	return Device
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/collection/globalvars.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/collection/globalvars.go
@@ -1,0 +1,25 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package collection
+
+var (
+	Nodeinfo NodeInfo
+	GPUs     []GPU
+	Mode     string
+	Node     string
+)

--- a/singa_auto_scheduler/pkg/sanodemonitor/collection/gpu.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/collection/gpu.go
@@ -1,0 +1,169 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.\
+package collection
+
+import (
+	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+)
+
+type GPU struct {
+	ID         uint
+	Health     string
+	FreeMemory uint64 // free memory of a GPU
+	Device     nvml.Device
+}
+
+type GpuScore struct {
+	Device GPU
+	Score  uint64
+}
+
+// check if GPU is healthy
+func CheckHealth() string {
+	for _, g := range GPUs {
+		// if one is healthy, then return
+		if g.Health == "Healthy" {
+			return "Healthy"
+		}
+	}
+	return "Unhealthy"
+}
+
+// check if there is GPU
+func CheckGPU() bool {
+	err := nvml.Init()
+	if err != nil {
+		log.ErrPrint("CheckGPU", err)
+	}
+	defer func() {
+		if err := nvml.Shutdown(); err != nil {
+			log.ErrPrint("CheckGPU", err)
+		}
+	}()
+	count, err := nvml.GetDeviceCount()
+	if err != nil {
+		log.ErrPrint("CheckGPU", err)
+	}
+	// check
+	if count > 0 {
+		return true
+	}
+	return false
+}
+
+// count number of GPU
+func CountGPU() uint {
+	err := nvml.Init()
+	if err != nil {
+		log.ErrPrint("CountGPU", err)
+	}
+	defer func() {
+		if err := nvml.Shutdown(); err != nil {
+			log.ErrPrint("CountGPU", err)
+		}
+	}()
+	count, err := nvml.GetDeviceCount()
+	if err != nil {
+		log.ErrPrint("CountGPU", err)
+	}
+	return count
+}
+
+func AddGPUInfo() error {
+	health := "Healthy"
+	err := nvml.Init()
+	if err != nil {
+		log.ErrPrint("AddGPUInfo", err)
+		return err
+	}
+	// define def below the error check
+	// because if there is error, no need to call def, return directly
+	// if error is not nil, it may cause panic when release resource
+	defer func() {
+		if err := nvml.Shutdown(); err != nil {
+			log.ErrPrint("AddGPUInfo", err)
+		}
+	}()
+	count, err := nvml.GetDeviceCount()
+	if err != nil {
+		log.ErrPrint("AddGPUInfo", err)
+		return err
+	}
+	for i := uint(0); i < count; i++ {
+		device, err := nvml.NewDevice(i)
+		if err != nil {
+			log.ErrPrint("AddGPUInfo", err)
+		}
+		status, err := device.Status()
+		if err != nil {
+			log.ErrPrint("AddGPUInfo", err)
+			health = "Unhealthy"
+		}
+
+		// add gpu info to global gpu list
+		GPUs = append(GPUs, GPU{
+			ID:         i,
+			Health:     health,
+			FreeMemory: *status.Memory.Global.Free,
+			Device:     *device,
+		})
+
+	}
+
+	return err
+}
+
+func UpdateGPU() error {
+	var NewGPUs []GPU
+	var health string = "Healthy"
+	err := nvml.Init()
+	if err != nil {
+		log.ErrPrint("UpdateGPU", err)
+	}
+	defer func() {
+		if err := nvml.Shutdown(); err != nil {
+			log.ErrPrint("UpdateGPU", err)
+		}
+	}()
+	count, err := nvml.GetDeviceCount()
+	if err != nil {
+		log.ErrPrint("UpdateGPU", err)
+	}
+	for i := uint(0); i < count; i++ {
+		device, err := nvml.NewDevice(i)
+		if err != nil {
+			log.ErrPrint("UpdateGPU", err)
+		}
+		status, err := device.Status()
+		if err != nil {
+			log.ErrPrint("UpdateGPU", err)
+			health = "Unhealthy"
+		}
+		NewGPUs = append(NewGPUs, GPU{
+			ID:         i,
+			Health:     health,
+			FreeMemory: *status.Memory.Global.Free,
+			Device:     *device,
+		})
+	}
+
+	// update global gpu
+	GPUs = NewGPUs
+	return err
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/collection/node.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/collection/node.go
@@ -1,0 +1,100 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package collection
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type NodeInfo struct {
+	Gpu           bool   // If the node has GPU, the value is true.
+	Health        string // If all GPU is unhealthy,the value is unhealthy. if one is healthy, it;s healthy
+	FreeMemorySum uint64 // The Sum of the free memory of the GPUs in one node
+	MaxFreeMemory uint64 // Max freeMemory of a gpu in one node
+	GpuSummary    string // "Gpu0_freeMemory" examples: Gpu0_100.Gpu1_200.Gpu2_300
+	Number        uint   // Number of GPus
+}
+
+func InitNodeInfoWithMaxFreeMemoryMode() {
+	InitModelNodeInfo(CalculateBestGPUWithMaxFreeMemoryMode)
+}
+
+func UpdateNodeInfoWithMaxFreeMemoryMode() {
+	UpdateModelNodeInfo(CalculateBestGPUWithMaxFreeMemoryMode)
+}
+
+func InitModelNodeInfo(Mode func() GPU) {
+	// Generate a global gpu list
+	if err := AddGPUInfo(); err != nil {
+		log.ErrPrint("InitModelNodeInfo", err)
+	}
+	// get the most greatest device to show, greatest is defined by the model,
+	// currently, we measure the score by using free memory, bigger is better
+	Device := Mode()
+	Nodeinfo = NodeInfo{
+		Gpu:           CheckGPU(),
+		Health:        CheckHealth(),
+		FreeMemorySum: CalculateGPUFreeMemorySum(),
+		MaxFreeMemory: Device.FreeMemory,
+		GpuSummary:    CalculateGpuSummary(),
+		Number:        CountGPU(),
+	}
+}
+
+func UpdateModelNodeInfo(Mode func() GPU) {
+	if err := UpdateGPU(); err != nil {
+		log.ErrPrint("UpdateModelNodeInfo", err)
+	}
+	Device := Mode()
+	Nodeinfo = NodeInfo{
+		Gpu:           CheckGPU(),
+		Health:        CheckHealth(),
+		FreeMemorySum: CalculateGPUFreeMemorySum(),
+		MaxFreeMemory: Device.FreeMemory,
+		GpuSummary:    CalculateGpuSummary(),
+		Number:        CountGPU(),
+	}
+}
+
+func NodeInfoToMap() map[string]string {
+	m := make(map[string]string)
+	var elem reflect.Value = reflect.ValueOf(Nodeinfo)
+	var relType reflect.Type = reflect.TypeOf(Nodeinfo)
+	//relType := elem.Type()
+	for i := 0; i < relType.NumField(); i++ {
+		if elem.Field(i).Type() == reflect.TypeOf("") {
+			m["samonitor/"+relType.Field(i).Name] = strings.Replace(elem.Field(i).String(), " ", "-", -1)
+		} else if elem.Field(i).Type() == reflect.TypeOf(true) {
+			m["samonitor/"+relType.Field(i).Name] = BoolToString(elem.Field(i).Bool())
+		} else {
+			m["samonitor/"+relType.Field(i).Name] = strconv.Itoa(int(elem.Field(i).Uint()))
+		}
+	}
+	return m
+}
+
+func BoolToString(value bool) string {
+	if value {
+		return "True"
+	} else {
+		return "False"
+	}
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/controller/cluster.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/controller/cluster.go
@@ -1,0 +1,48 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package controller
+
+import (
+	"errors"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var Config *rest.Config
+
+func InitInClusterConfig() {
+	err := errors.New("")
+	// InClusterConfig
+	log.Print("Init kubernetes Config. ")
+	Config, err = rest.InClusterConfig()
+	if err != nil {
+		log.ErrPrint("InitInClusterConfig", err)
+	}
+}
+
+func InitOutOfClusterConfig() {
+	err := errors.New("")
+	log.Print("Init kubernetes Config. ")
+	Config, err = clientcmd.BuildConfigFromFlags(
+		"",
+		"/root/.kube/config")
+	if err != nil {
+		log.ErrPrint("InitOutOfClusterConfig", err)
+	}
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/controller/label.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/controller/label.go
@@ -1,0 +1,104 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controller
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/collection"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"strings"
+)
+
+func UpdateNodeLabel(name string) {
+	// convert node info instance to map
+	label := collection.NodeInfoToMap()
+
+	client, err := kubernetes.NewForConfig(Config)
+	if err != nil {
+		panic(err)
+	}
+	node, err := client.CoreV1().Nodes().Get(name, v1.GetOptions{})
+	if err != nil {
+		log.ErrPrint("UpdateNodeLabel", err)
+	} else {
+		if DoesUpdateNodeLabel(name) {
+			log.Print("Label Changed, ready to update.")
+			nodeLabel := node.GetLabels()
+			for i, v := range label {
+				nodeLabel[i] = v
+			}
+			// update label
+			node.SetLabels(nodeLabel)
+			if _, err := client.CoreV1().Nodes().Update(node); err != nil {
+				log.ErrPrint("UpdateNodeLabel", err)
+			}
+		}
+	}
+}
+
+func CleanNodeLabel(name string) {
+	client, err := kubernetes.NewForConfig(Config)
+	if err != nil {
+		panic(err)
+	}
+	node, err := client.CoreV1().Nodes().Get(name, v1.GetOptions{})
+	if err != nil {
+		log.ErrPrint("CleanNodeLabel", err)
+	} else {
+		nodeLabel := node.GetLabels()
+		for i := range nodeLabel {
+			if strings.Contains(i, "SaMonitor/") {
+				delete(nodeLabel, i)
+			}
+		}
+		node.SetLabels(nodeLabel)
+		if _, err := client.CoreV1().Nodes().Update(node); err != nil {
+			log.ErrPrint("CleanNodeLabel", err)
+		}
+	}
+}
+
+// check if the node label is needed to update
+func DoesUpdateNodeLabel(name string) bool {
+	client, err := kubernetes.NewForConfig(Config)
+	if err != nil {
+		panic(err)
+	}
+	node, err := client.CoreV1().Nodes().Get(name, v1.GetOptions{})
+	if err != nil {
+		log.ErrPrint("DoesUpdateNodeLabel", err)
+	} else {
+		nodeLabel := node.GetLabels()
+		for k, v := range collection.NodeInfoToMap() {
+
+			if value, ok := nodeLabel[k]; ok {
+				// if the current label of node
+				// is not the same as latest node info label
+				if value != v {
+					return true
+				}
+				// if nodeLabel dont have such key,
+			} else {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/controller/node.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/controller/node.go
@@ -1,0 +1,47 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package controller
+
+import (
+	"encoding/json"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/collection"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+)
+
+func InitNodeInfo(mode string) {
+	log.Print("Init Monitor, mode:" + mode)
+	switch mode {
+	case "MaxFreeMemory":
+		collection.InitNodeInfoWithMaxFreeMemoryMode()
+	}
+}
+
+func UpdateNodeInfo(mode string) {
+	switch mode {
+	case "MaxFreeMemory":
+		collection.UpdateNodeInfoWithMaxFreeMemoryMode()
+	}
+}
+
+func PrintNodeInfo() {
+	s, err := json.Marshal(&collection.Nodeinfo)
+	if err != nil {
+		log.ErrPrint("PrintNodeInfo", err)
+	}
+	log.Print("Node Info: " + string(s))
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/crontabjob/task.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/crontabjob/task.go
@@ -1,0 +1,43 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package crontabjob
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/collection"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/controller"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sanodemonitor/log"
+	"github.com/robfig/cron"
+	"sync"
+)
+
+func Update(c *cron.Cron, name string) {
+
+	// every 1 min, update node info and label
+	if err := c.AddFunc("*/1 * * * * ?", func() {
+		controller.UpdateNodeInfo(collection.Mode)
+		controller.UpdateNodeLabel(name)
+	}); err != nil {
+		log.ErrPrint("Update", err)
+	}
+}
+
+func Start(c *cron.Cron, w *sync.WaitGroup) {
+	// Add 1 to the counter
+	w.Add(1)
+	c.Start()
+}

--- a/singa_auto_scheduler/pkg/sanodemonitor/log/log.go
+++ b/singa_auto_scheduler/pkg/sanodemonitor/log/log.go
@@ -1,0 +1,31 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package log
+
+import (
+	"fmt"
+	"time"
+)
+
+func ErrPrint(method string, err error) {
+	fmt.Printf("[SaMonitor]-[%s] Error in [%s]: %s\n", time.Now(), method, err)
+}
+
+func Print(log string) {
+	fmt.Printf("[SaMonitor]-[%s]  %s\n", time.Now(), log)
+}

--- a/singa_auto_scheduler/pkg/sascheduler/collection/cons.go
+++ b/singa_auto_scheduler/pkg/sascheduler/collection/cons.go
@@ -1,0 +1,22 @@
+package collection
+
+import framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+
+const (
+	AppName           = "sascheduler"
+	NodeSelectorLabel = "kubernetes.io/hostname"
+)
+
+var Sum = []string{"FreeMemorySum", "MaxFreeMemory", "Number"}
+
+type Data struct {
+	Value  int64
+	SValue string
+}
+
+func (s *Data) Clone() framework.StateData {
+	c := &Data{
+		Value: s.Value,
+	}
+	return c
+}

--- a/singa_auto_scheduler/pkg/sascheduler/collection/utils.go
+++ b/singa_auto_scheduler/pkg/sascheduler/collection/utils.go
@@ -1,0 +1,19 @@
+package collection
+
+import "strconv"
+
+func StrToUInt(str string) uint {
+	if i, e := strconv.Atoi(str); e != nil {
+		return 0
+	} else {
+		return uint(i)
+	}
+}
+
+func StrToInt64(str string) int64 {
+	if i, e := strconv.Atoi(str); e != nil {
+		return 0
+	} else {
+		return int64(i)
+	}
+}

--- a/singa_auto_scheduler/pkg/sascheduler/filter/algorithm.go
+++ b/singa_auto_scheduler/pkg/sascheduler/filter/algorithm.go
@@ -1,0 +1,65 @@
+package filter
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"strings"
+)
+
+func MatchGpu2Pod(
+	pod *v1.Pod,
+	nodes []*v1.Node,
+	filteredNodesStatuses framework.NodeToStatusMap) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			klog.V(3).Infof("ErrorMsg in MatchGpu2Pod: %v", err)
+		}
+	}()
+
+	matchGpu2Pod(pod, nodes, filteredNodesStatuses)
+}
+
+func matchGpu2Pod(
+	pod *v1.Pod,
+	nodes []*v1.Node,
+	filteredNodesStatuses framework.NodeToStatusMap) {
+
+	var selectGpu string
+	var selectNodeName string
+	var maxFreeMemory int64 = 0
+
+	for _, n := range nodes {
+		if filteredNodesStatuses[n.GetName()].IsSuccess() {
+
+			// if the node is filtered, get needed node info
+			nodeName := n.Labels[collection.NodeSelectorLabel]
+			gpuSummary := n.Labels["samonitor/GpuSummary"]
+
+			for _, GpuMemory := range strings.Split(gpuSummary, ".") {
+				var gpu string = strings.Split(GpuMemory, "_")[0]
+				var freeMemory int64 = collection.StrToInt64(strings.Split(GpuMemory, "_")[1])
+
+				// find the max gpu device number and it's corresponding node
+				if freeMemory > maxFreeMemory {
+					selectNodeName = nodeName
+					selectGpu = gpu
+				}
+			}
+		}
+	}
+
+	// assign env to the pod env
+	containers := pod.Spec.Containers
+
+	for _, container := range containers {
+
+		envVar := v1.EnvVar{Name: "NVIDIA_VISIBLE_DEVICES", Value: selectGpu}
+		container.Env = append(container.Env, envVar)
+	}
+	// assign node label to the pod env
+	pod.Spec.NodeSelector[collection.NodeSelectorLabel] = selectNodeName
+
+}

--- a/singa_auto_scheduler/pkg/sascheduler/filter/filter.go
+++ b/singa_auto_scheduler/pkg/sascheduler/filter/filter.go
@@ -1,0 +1,85 @@
+package filter
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+func NodeHasGPU(node *nodeinfo.NodeInfo) bool {
+	if _, ok := node.Node().Labels["samonitor/Gpu"]; ok {
+		if node.Node().Labels["samonitor/Gpu"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+func NodeGPUHealth(node *nodeinfo.NodeInfo) bool {
+	if node.Node().Labels["samonitor/Health"] == "Healthy" {
+		return true
+	}
+	return false
+}
+
+func CheckGPUStatus(node *nodeinfo.NodeInfo) (bool, string) {
+	var msg = ""
+	if NodeHasGPU(node) {
+		if NodeGPUHealth(node) {
+			return true, msg
+		}
+		return false, "GPU Unhealthy"
+	}
+	return false, "No GPU"
+}
+
+func NodeHasGPUNumber(node *nodeinfo.NodeInfo) bool {
+	_, ok := node.Node().Labels["samonitor/Number"]
+	return ok
+}
+
+func NodeHasFreeMemory(node *nodeinfo.NodeInfo) bool {
+	_, ok := node.Node().Labels["samonitor/MaxFreeMemory"]
+	return ok
+}
+
+type PodInfo struct {
+	Pod  *v1.Pod
+	Node *nodeinfo.NodeInfo
+}
+
+// private methods
+func (p *PodInfo) podNeedMemory() bool {
+	_, ok := (*p).Pod.Labels["samonitor/MaxFreeMemory"]
+	return ok
+}
+
+// private methods
+func (p *PodInfo) podNeedGPUNumber() bool {
+	_, ok := (*p).Pod.Labels["samonitor/Number"]
+	return ok
+}
+
+// public methods
+func (p *PodInfo) PodFitsMemory() bool {
+	if p.podNeedMemory() {
+		if NodeHasFreeMemory((*p).Node) {
+			return collection.StrToUInt((*p).Node.Node().Labels["samonitor/MaxFreeMemory"]) >=
+				collection.StrToUInt((*p).Pod.Labels["samonitor/MaxFreeMemory"])
+		}
+		return false
+	}
+	return true
+}
+
+// public methods
+func (p *PodInfo) PodFitsNumber() bool {
+	if p.podNeedGPUNumber() {
+		if NodeHasGPUNumber((*p).Node) {
+			return collection.StrToUInt((*p).Node.Node().Labels["samonitor/Number"]) >=
+				collection.StrToUInt((*p).Pod.Labels["samonitor/Number"])
+		}
+		return false
+	}
+	return true
+}

--- a/singa_auto_scheduler/pkg/sascheduler/filter/postfilter.go
+++ b/singa_auto_scheduler/pkg/sascheduler/filter/postfilter.go
@@ -1,0 +1,81 @@
+package filter
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"sync"
+)
+
+const Workers int = 4
+
+func CollectMaxValue(
+	value string,
+	state *framework.CycleState,
+	nodes []*v1.Node,
+	filteredNodesStatuses framework.NodeToStatusMap) *framework.Status {
+
+	Max := collection.Data{Value: 0}
+	for _, n := range nodes {
+		if filteredNodesStatuses[n.GetName()].IsSuccess() {
+			if collection.StrToInt64(n.Labels["samonitor/"+value]) > Max.Value {
+				Max.Value = collection.StrToInt64(n.Labels["samonitor/MaxFreeMemory"])
+			}
+		}
+	}
+	if Max.Value == 0 {
+		return framework.NewStatus(framework.Error, " The max "+value+" of the nodes is 0")
+	}
+	state.Lock()
+	state.Write(framework.StateKey("Max"+value), &Max)
+	defer state.Unlock()
+	return framework.NewStatus(framework.Success, "")
+}
+
+func ParallelCollection(
+	workers int,
+	state *framework.CycleState,
+	nodes []*v1.Node,
+	filteredNodesStatuses framework.NodeToStatusMap) *framework.Status {
+
+	var (
+		stop <-chan struct{}
+		mx   sync.RWMutex
+		msg  = ""
+	)
+	pieces := len(collection.Sum)
+	toProcess := make(chan string, pieces)
+	for _, v := range collection.Sum {
+		toProcess <- v
+	}
+	close(toProcess)
+	if pieces < workers {
+		workers = pieces
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for value := range toProcess {
+				select {
+				case <-stop:
+					return
+				default:
+					if re := CollectMaxValue(value, state, nodes, filteredNodesStatuses); !re.IsSuccess() {
+						klog.V(3).Infof(re.Message())
+						mx.Lock()
+						msg += re.Message()
+						mx.Unlock()
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if msg != "" {
+		return framework.NewStatus(framework.Error, msg)
+	}
+	return framework.NewStatus(framework.Success, "")
+}

--- a/singa_auto_scheduler/pkg/sascheduler/register.go
+++ b/singa_auto_scheduler/pkg/sascheduler/register.go
@@ -1,0 +1,13 @@
+package sascheduler
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/cmd/kube-scheduler/app"
+)
+
+func Register() *cobra.Command {
+	return app.NewSchedulerCommand(
+		app.WithPlugin(collection.AppName, New),
+	)
+}

--- a/singa_auto_scheduler/pkg/sascheduler/scheduler.go
+++ b/singa_auto_scheduler/pkg/sascheduler/scheduler.go
@@ -1,0 +1,222 @@
+package sascheduler
+
+import (
+	"context"
+	"fmt"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/filter"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/score"
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/sort"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+var (
+	_ framework.QueueSortPlugin  = &SingaAutoScheduler{}
+	_ framework.FilterPlugin     = &SingaAutoScheduler{}
+	_ framework.PostFilterPlugin = &SingaAutoScheduler{}
+	_ framework.ScorePlugin      = &SingaAutoScheduler{}
+	_ framework.ScoreExtensions  = &SingaAutoScheduler{}
+)
+
+type Args struct {
+	KubeConfig string `json:"kubeconfig,omitempty"`
+	Master     string `json:"master,omitempty"`
+}
+
+type SingaAutoScheduler struct {
+	args   *Args
+	handle framework.FrameworkHandle
+}
+
+func (s *SingaAutoScheduler) Name() string {
+	return collection.AppName
+}
+
+// This is pre-filter method, this is for v1.18+
+func (s *SingaAutoScheduler) PreFilter(
+	ctx context.Context,
+	state *framework.CycleState,
+	p *v1.Pod) *framework.Status {
+
+	klog.V(3).Infof("pre-filter pod: %v", p.Name)
+	return framework.NewStatus(framework.Success, "")
+}
+
+// called on each node
+func (s *SingaAutoScheduler) Filter(
+	ctx context.Context,
+	state *framework.CycleState,
+	pod *v1.Pod,
+	node *schedulernodeinfo.NodeInfo) *framework.Status {
+
+	klog.V(3).Infof("filter pod: %v, node: %v", pod.Name, node.Node().Name)
+
+	// if the pod has pre defined node info
+	if nodeName, ok := pod.Spec.NodeSelector[collection.NodeSelectorLabel]; ok {
+		klog.V(3).Infof("filter: pod NodeSelector is: %v", pod.Spec.NodeSelector)
+
+		// if current node is "the node", return success
+		if node.Node().Labels[collection.NodeSelectorLabel] == nodeName {
+			return framework.NewStatus(framework.Success, "")
+		} else {
+			// if current node is not "the node", return Unscheduable
+			return framework.NewStatus(framework.Unschedulable,
+				"Node:"+node.Node().Name+" Pod is assigned to "+nodeName)
+		}
+	} else {
+		// check if node has gpu, and if gpu is available
+		if ok, msg := filter.CheckGPUStatus(node); ok {
+
+			// init podInfo, type of pointer
+			var podInfo = &filter.PodInfo{Pod: pod, Node: node}
+
+			if !podInfo.PodFitsMemory() {
+				return framework.NewStatus(
+					framework.Unschedulable,
+					"Node:"+node.Node().Name+" GPU Memory Not Fit")
+			}
+			if !podInfo.PodFitsNumber() {
+				return framework.NewStatus(
+					framework.Unschedulable,
+					"Node:"+node.Node().Name+" GPU Memory Not Fit")
+			}
+			return framework.NewStatus(
+				framework.Success,
+				"")
+		} else {
+			return framework.NewStatus(
+				framework.Unschedulable,
+				"Node: "+node.Node().Name+msg)
+		}
+	}
+}
+
+// this is used to sort the pods according to the priority
+func (s *SingaAutoScheduler) Less(podInfo1, podInfo2 *framework.PodInfo) bool {
+	return sort.Less(podInfo1, podInfo2)
+}
+
+// post-filter in 1.17 is also called pre-score in 1.18,
+// this is for v 1.17+, 1.18 doesnt have filteredNodesStatuses in in pre-score
+// can not get filter result. so switched to 1.17
+// all filtered node info can be found there
+func (s *SingaAutoScheduler) PostFilter(
+	ctx context.Context,
+	state *framework.CycleState,
+	pod *v1.Pod,
+	nodes []*v1.Node,
+	filteredNodesStatuses framework.NodeToStatusMap) *framework.Status {
+
+	// state is data store shared by all plugins. here add customer info to state
+	klog.V(3).Infof("collect info for scheduling  pod: %v", pod.Name)
+
+	// if the pod dont have pre-assigned node info, find one for it
+	if _, ok := pod.Spec.NodeSelector[collection.NodeSelectorLabel]; !ok {
+
+		// select a best node and gpu according to node's GpuSummary
+		filter.MatchGpu2Pod(pod, nodes, filteredNodesStatuses)
+
+	}
+
+	return filter.ParallelCollection(filter.Workers, state, nodes, filteredNodesStatuses)
+}
+
+// Score is called on each filtered node,
+// It must return success and an integer indicating the rank of the node.
+// state is data store shared by all plugins.
+func (s *SingaAutoScheduler) Score(
+	ctx context.Context,
+	state *framework.CycleState,
+	pod *v1.Pod,
+	nodeName string) (int64, *framework.Status) {
+
+	// This information should only be used before "Reserve" point
+	// Get the node info of the filtered node
+	nodeInfo, err := s.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
+	if err != nil {
+		return 0, framework.NewStatus(framework.Error,
+			fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
+	}
+
+	// if the pod has pre defined node info
+	if nodeName, ok := pod.Spec.NodeSelector[collection.NodeSelectorLabel]; ok {
+		klog.V(3).Infof("score: pod NodeSelector is: %v", pod.Spec.NodeSelector)
+
+		// if current node is "the node", return 100
+		if nodeInfo.Node().Labels[collection.NodeSelectorLabel] == nodeName {
+			return 100, framework.NewStatus(framework.Error,
+				fmt.Sprintf("Score Node Error: %v", err))
+			// if current node is not "the node", return 0
+		} else {
+			return 0, framework.NewStatus(framework.Error,
+				fmt.Sprintf("Score Node Error: %v", err))
+
+		}
+	} else {
+		// if assign gpu or node fail, apply the default method to calculate a score for each node
+		// calculate the score according to node and pod
+		res, err := score.Score(state, nodeInfo)
+		if err != nil {
+			return 0, framework.NewStatus(framework.Error,
+				fmt.Sprintf("Score Node Error: %v", err))
+		}
+		klog.V(3).Infof("node : %v sa-scheduler score: %v", nodeName, s)
+		return res, framework.NewStatus(framework.Success, "")
+	}
+}
+
+func (s *SingaAutoScheduler) NormalizeScore(
+	ctx context.Context,
+	state *framework.CycleState,
+	p *v1.Pod,
+	scores framework.NodeScoreList) *framework.Status {
+
+	var (
+		highest int64 = 0
+		lowest        = scores[0].Score
+	)
+	for _, nodeScore := range scores {
+		if nodeScore.Score < lowest {
+			lowest = nodeScore.Score
+		}
+	}
+	if lowest < 0 {
+		for i := range scores {
+			scores[i].Score -= lowest
+		}
+	}
+	for _, nodeScore := range scores {
+		if nodeScore.Score > highest {
+			highest = nodeScore.Score
+		}
+	}
+	// Set Range to [0-100]
+	for i, nodeScore := range scores {
+		scores[i].Score = nodeScore.Score * framework.MaxNodeScore / highest
+	}
+	return framework.NewStatus(framework.Success, "")
+}
+
+func (s *SingaAutoScheduler) ScoreExtensions() framework.ScoreExtensions {
+	return s
+}
+
+func New(
+	configuration *runtime.Unknown,
+	f framework.FrameworkHandle) (framework.Plugin, error) {
+
+	args := &Args{}
+	if err := framework.DecodeInto(configuration, args); err != nil {
+		return nil, err
+	}
+	klog.V(3).Infof("get plugin config args: %+v", args)
+
+	return &SingaAutoScheduler{
+		args:   args,
+		handle: f,
+	}, nil
+}

--- a/singa_auto_scheduler/pkg/sascheduler/score/computation.go
+++ b/singa_auto_scheduler/pkg/sascheduler/score/computation.go
@@ -1,0 +1,48 @@
+package score
+
+import (
+	"github.com/naili-xing/singa_auto_scheduler/pkg/sascheduler/collection"
+	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+var Weights = make(map[string]int64)
+
+func Sum2WeightMap() {
+	var weight int64 = 1
+	for _, ele := range collection.Sum {
+		// by default , all weight is 1 for each key in Sum: filter.Sum
+		Weights[ele] = weight
+	}
+}
+
+func CalculateCollectScore(
+	state *framework.CycleState,
+	node *nodeinfo.NodeInfo) (int64, error) {
+
+	Sum2WeightMap()
+	var score int64 = 0
+	for v, w := range Weights {
+		s, err := CalculateValueScore(v, state, node)
+		if err != nil {
+			return 0, err
+		}
+		score += s * w
+	}
+	return score, nil
+}
+
+func CalculateValueScore(
+	value string,
+	state *framework.CycleState,
+	node *nodeinfo.NodeInfo) (int64, error) {
+
+	d, err := state.Read(framework.StateKey("Max" + value))
+	if err != nil {
+		klog.V(3).Infof("Error Get CycleState Info: %v", err)
+		return 0, err
+	}
+	// type assertion
+	return collection.StrToInt64(node.Node().Labels["samonitor/"+value]) * 100 / d.(*collection.Data).Value, nil
+}

--- a/singa_auto_scheduler/pkg/sascheduler/score/score.go
+++ b/singa_auto_scheduler/pkg/sascheduler/score/score.go
@@ -1,0 +1,14 @@
+package score
+
+import (
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+func Score(state *framework.CycleState, node *nodeinfo.NodeInfo) (int64, error) {
+	score, err := CalculateCollectScore(state, node)
+	if err != nil {
+		return 0, err
+	}
+	return score, nil
+}

--- a/singa_auto_scheduler/pkg/sascheduler/sort/sort.go
+++ b/singa_auto_scheduler/pkg/sascheduler/sort/sort.go
@@ -1,0 +1,23 @@
+package sort
+
+import framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+
+func Less(podInfo1, podInfo2 *framework.PodInfo) bool {
+	return GetPodPriority(podInfo1) > GetPodPriority(podInfo2)
+}
+
+func GetPodPriority(podInfo *framework.PodInfo) uint {
+	var pod uint = 0
+	// if the pod has such label, use them to sort
+	if _, ok := podInfo.Pod.Labels["Level"]; ok {
+		switch podInfo.Pod.Labels["Level"] {
+		case "High":
+			pod = 3
+		case "Medium":
+			pod = 2
+		case "Low":
+			pod = 1
+		}
+	}
+	return pod
+}


### PR DESCRIPTION
This is already deployed on the cluster:

One package includes 2 apps:(gpu realtime monitor & scheduler)

monitor:

<img width="384" alt="截屏2020-08-03 上午1 30 04" src="https://user-images.githubusercontent.com/57171759/89128541-f25fe380-d528-11ea-90b2-51598eb58981.png">

Monitor info:

samonitor/FreeMemorySum=29416,
samonitor/Gpu=True,
samonitor/GpuSummary=0_11159.1_7101.2_11156, (format of  GPU_id_freeMemory.GPU_id_freeMemory.GPU_id_freeMemory)
samonitor/Health=Healthy,
samonitor/MaxFreeMemory=11159,
samonitor/Number=3

Scheduler framework is coded with 1.17 api, our currently platform is 1.15, not compatiable, if we update our platform to 1.17, it;s working