### PR TITLE
make onnx examples compatible

### DIFF
--- a/examples/models/image_object_detection/onnx_tiny_yolov2.py
+++ b/examples/models/image_object_detection/onnx_tiny_yolov2.py
@@ -217,7 +217,9 @@ if __name__ == '__main__':
 
     (predictions, model_inst) = make_predictions(queries, task,
                                                  py_model_class,
-                                                 proposal, params={})
+                                                 proposal,
+                                                 fine_tune_dataset_path=None,
+                                                 params={})
 
     py_model_class.teardown()
 

--- a/examples/models/question_answering/onnx_bert/onnx_bert.py
+++ b/examples/models/question_answering/onnx_bert/onnx_bert.py
@@ -206,7 +206,9 @@ if __name__ == '__main__':
 
     (predictions, model_inst) = make_predictions(queries, task,
                                                  py_model_class,
-                                                 proposal, params={})
+                                                 proposal,
+                                                 fine_tune_dataset_path=None,
+                                                 params={})
 
     py_model_class.teardown()
 

--- a/examples/models/text_generation/onnx_gpt2.py
+++ b/examples/models/text_generation/onnx_gpt2.py
@@ -152,7 +152,9 @@ if __name__ == '__main__':
 
     (predictions, model_inst) = make_predictions(queries, task,
                                                  py_model_class,
-                                                 proposal, params={})
+                                                 proposal,
+                                                 fine_tune_dataset_path=None,
+                                                 params={})
 
     py_model_class.teardown()
 


### PR DESCRIPTION
After my last PR, I saw someone else changed the `make_predictions` function and added a param called `fine_tune_dataset_path`, so I have to change my code to make it compatible.