### PR TITLE
Bug fixing for admin dockerfile, pls merge

### DIFF
--- a/dockerfiles/admin.Dockerfile
+++ b/dockerfiles/admin.Dockerfile
@@ -19,11 +19,11 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get -y upgrade
 
 # Install conda with pip and python 3.6
 ARG CONDA_ENVIORNMENT
-RUN apt-get -y install curl bzip2 \
+RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y \
+  curl bzip2 \
   && curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh \
   && bash /tmp/miniconda.sh -bfp /usr/local \
   && rm -rf /tmp/miniconda.sh \


### PR DESCRIPTION
To prevent caching the update and install separately.
if you change the installation line, it will still use the old package cache, which will often have problems if the cache is out of date (usually, files will 404.) 
Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail.

Reference:
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
https://askubuntu.com/questions/519539/failed-to-fetch-http-security-ubuntu-com-ubuntu-pool-main-e-eglibc-libc-bin-2